### PR TITLE
Fix Flaky Test BeanToArrayGenerationTestCase.java

### DIFF
--- a/core/src/test/java/ma/glasnost/orika/test/generator/BeanToArrayGenerationTestCase.java
+++ b/core/src/test/java/ma/glasnost/orika/test/generator/BeanToArrayGenerationTestCase.java
@@ -41,6 +41,8 @@ public class BeanToArrayGenerationTestCase {
                 .field("grade.percentage", "2")
                 .field("name.first", "3")
                 .field("name.last", "4")
+		.field("id", "5")
+                .field("email", "6")
                 .byDefault()
                 .register();
         
@@ -93,6 +95,8 @@ public class BeanToArrayGenerationTestCase {
                 .field("grade.percentage", "2")
                 .field("name.first", "3")
                 .field("name.last", "4")
+		.field("id", "5")
+                .field("email", "6")
                 .byDefault()
                 .register();
         


### PR DESCRIPTION
**Problem:**
The testBeanToArrayGeneration and testBeanToStringArrayGeneration methods were sometimes failing due to missing mappings for the id and email fields in the MapperFactory. Specifically, these fields were not included in the mapping configuration, which led to inconsistencies when mapping the Student object to an array and back.

Without these mappings, the tests rely on the default Java behavior to handle unmapped fields, which does not guarantee consistent results for non-primitive fields like id and email. This behavior caused the tests to occasionally fail. The fields id and email were not explicitly mapped, making their array indices unpredictable and causing the round-trip mapping (from object to array and back) to fail in certain scenarios.

**Solution:**
The solution is to explicitly map the id and email fields in both tests to ensure consistent behavior. These changes were made in both testBeanToArrayGeneration and testBeanToStringArrayGeneration to prevent the default behavior from misinterpreting these fields.
